### PR TITLE
[Feat/#7] BaseEntity 추가

### DIFF
--- a/src/main/java/com/example/deliveryapp/domain/menu/entity/Menu.java
+++ b/src/main/java/com/example/deliveryapp/domain/menu/entity/Menu.java
@@ -1,6 +1,8 @@
 package com.example.deliveryapp.domain.menu.entity;
 
 import com.example.deliveryapp.domain.store.entity.Store;
+import com.example.deliveryapp.global.common.BaseEntity;
+import com.example.deliveryapp.global.common.BaseTimeEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -19,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Table(name = "menu")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Menu {
+public class Menu extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/example/deliveryapp/domain/order/entity/Order.java
+++ b/src/main/java/com/example/deliveryapp/domain/order/entity/Order.java
@@ -5,6 +5,7 @@ import java.util.List;
 import com.example.deliveryapp.domain.menu.entity.Menu;
 import com.example.deliveryapp.domain.store.entity.Store;
 import com.example.deliveryapp.domain.user.entity.User;
+import com.example.deliveryapp.global.common.BaseEntity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -21,9 +22,9 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "order")
+@Table(name = "order_table")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Order {
+public class Order extends BaseEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/deliveryapp/domain/order/entity/OrderMenu.java
+++ b/src/main/java/com/example/deliveryapp/domain/order/entity/OrderMenu.java
@@ -1,6 +1,7 @@
 package com.example.deliveryapp.domain.order.entity;
 
 import com.example.deliveryapp.domain.menu.entity.Menu;
+import com.example.deliveryapp.global.common.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -18,18 +19,18 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class OrderMenu {
+public class OrderMenu extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "order_menu_id", nullable = false)
 	private Long id;
 
 	@ManyToOne
-	@JoinColumn(name = "order_id")
+	@JoinColumn(name = "order_table_id")
 	private Order order;
 
 	@OneToOne
-	@JoinColumn(name = "menu_id")
+	@JoinColumn(name = "menu")
 	private Menu menu;
 
 }

--- a/src/main/java/com/example/deliveryapp/domain/review/entity/Review.java
+++ b/src/main/java/com/example/deliveryapp/domain/review/entity/Review.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.example.deliveryapp.domain.store.entity.Store;
 import com.example.deliveryapp.domain.user.entity.User;
+import com.example.deliveryapp.global.common.BaseEntity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -18,9 +19,8 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "review")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Review {
+public class Review extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/example/deliveryapp/domain/review/entity/ReviewImage.java
+++ b/src/main/java/com/example/deliveryapp/domain/review/entity/ReviewImage.java
@@ -1,5 +1,7 @@
 package com.example.deliveryapp.domain.review.entity;
 
+import com.example.deliveryapp.global.common.BaseEntity;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -15,7 +17,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ReviewImage {
+public class ReviewImage extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "review_image_id", nullable = false)

--- a/src/main/java/com/example/deliveryapp/domain/store/entity/Store.java
+++ b/src/main/java/com/example/deliveryapp/domain/store/entity/Store.java
@@ -2,15 +2,15 @@ package com.example.deliveryapp.domain.store.entity;
 
 import com.example.deliveryapp.domain.menu.entity.Menu;
 import com.example.deliveryapp.domain.store.enumerate.StoreCategory;
+import com.example.deliveryapp.global.common.BaseEntity;
 
 import jakarta.persistence.*;
 import lombok.*;
 
 @Entity
 @Getter
-@Table(name = "store")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Store {
+public class Store extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Column(name = "store_id", nullable = false)

--- a/src/main/java/com/example/deliveryapp/domain/user/entity/User.java
+++ b/src/main/java/com/example/deliveryapp/domain/user/entity/User.java
@@ -1,6 +1,8 @@
 package com.example.deliveryapp.domain.user.entity;
 
 import com.example.deliveryapp.domain.store.entity.Store;
+import com.example.deliveryapp.global.common.BaseEntity;
+import com.example.deliveryapp.global.common.BaseTimeEntity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -15,9 +17,8 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "user")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User {
+public class User extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;

--- a/src/main/java/com/example/deliveryapp/global/common/AuditorAwareImpl.java
+++ b/src/main/java/com/example/deliveryapp/global/common/AuditorAwareImpl.java
@@ -1,0 +1,16 @@
+package com.example.deliveryapp.global.common;
+
+import java.util.Optional;
+
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditorAwareImpl implements AuditorAware<String> {
+
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        //TODO 인증된 사용자 정보 가져오기
+        return Optional.of("mihye");
+    }
+}

--- a/src/main/java/com/example/deliveryapp/global/common/BaseEntity.java
+++ b/src/main/java/com/example/deliveryapp/global/common/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.example.deliveryapp.global.common;
+
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity extends BaseTimeEntity {
+	@CreatedBy
+	@Column(updatable = false)
+	private String createdBy;
+
+	@LastModifiedBy
+	private String updatedBy;
+}

--- a/src/main/java/com/example/deliveryapp/global/common/BaseTimeEntity.java
+++ b/src/main/java/com/example/deliveryapp/global/common/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.example.deliveryapp.global.common;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@MappedSuperclass
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+	@CreatedDate
+	@Column(updatable = false)
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 🚩 관련 이슈
- close #7 

## 📋 구현 기능 명세
- [x] BaseEntity 추가

## 📌 PR Point
- 무슨 이유로 어떻게 코드를 변경했는지
createdBy와 updateBy는 상황에따라 안쓰이는 엔티티도 있을거같아서 BaseTimeEntity를 생성하고 그것을 상속받는 BaseEntity에 createdBy와 updateBy를 정의하였습니다.

현재 사용자를 인증하는 로직이 없으므로 사용자 감지할때 임시로 mihye로 정의하였습니다.
